### PR TITLE
Fix timezone handling for API datetime responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING**: Fixed timezone handling for API datetime responses
+- Datetime objects returned by `start_date` and `end_date` are now timezone-aware in local time instead of incorrectly parsed as UTC
+- Added configurable timezone support to `DropCountrClient` constructor (defaults to `America/Los_Angeles`)
+- API timestamps with 'Z' suffix are now correctly interpreted as local time rather than UTC
+
+### Added
+- Timezone configuration parameter to `DropCountrClient.__init__(timezone=...)`
+- Support for custom timezones using IANA timezone names or `ZoneInfo` objects
+- All datetime properties now return timezone-aware datetime objects
+
 ## [0.1.2] - 2025-01-03
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,11 @@ if service:
 ### Fetch Usage Data
 ```python
 from datetime import datetime
+from zoneinfo import ZoneInfo
+
+# Create client with timezone (defaults to Pacific)
+client = DropCountrClient()
+# Or specify custom timezone: client = DropCountrClient(timezone="America/New_York")
 
 # Get daily usage data for June 2025 using Python datetime objects
 usage = client.get_usage(
@@ -66,7 +71,9 @@ usage = client.get_usage(
 if usage:
     print(f"Total records: {usage.total_items}")
     for record in usage.usage_data[:3]:
-        print(f"{record.start_date.date()}: {record.total_gallons} gallons")
+        # Now correctly timezone-aware in local time
+        print(f"{record.start_date}: {record.total_gallons} gallons")
+        print(f"Timezone: {record.start_date.tzinfo}")
 
 # Alternative: You can still use ISO datetime strings
 usage = client.get_usage(
@@ -99,7 +106,27 @@ usage = client.get_usage(
 - **Service Discovery**: Use `list_service_connections()` to discover available service connection IDs
 - **Date Parameters**: The library accepts both Python `datetime` objects (recommended) and ISO 8601 datetime strings
 - When using datetime objects, the library automatically converts them to the required API format
-- Timezone handling: datetime objects are converted to UTC with 'Z' suffix for API compatibility
+
+## Timezone Handling (v0.1.3+)
+- **Breaking Change**: Fixed incorrect UTC parsing - API timestamps are actually in local time despite 'Z' suffix
+- **Default Timezone**: Pacific Time (`America/Los_Angeles`) - configurable via `DropCountrClient(timezone=...)`
+- **Custom Timezones**: Support any IANA timezone name or `ZoneInfo` object
+- **Timezone-Aware**: All `start_date` and `end_date` properties return timezone-aware datetime objects
+- **API Compatibility**: Input datetime objects are still converted to UTC with 'Z' suffix for API requests
+- **Standard Library**: Uses Python 3.12+ `zoneinfo` module (no external dependencies)
+
+### Timezone Usage:
+```python
+# Default Pacific timezone
+client = DropCountrClient()
+
+# Custom timezone by name
+client = DropCountrClient(timezone="America/New_York")
+
+# Custom timezone by ZoneInfo
+from zoneinfo import ZoneInfo
+client = DropCountrClient(timezone=ZoneInfo("UTC"))
+```
 
 ## Changelog Management
 

--- a/pydropcountr/cli.py
+++ b/pydropcountr/cli.py
@@ -19,10 +19,14 @@ class DropCountrCLI:
     def __init__(self, debug: bool = False):
         self.debug = debug
         if debug:
-            logging.basicConfig(level=logging.DEBUG, format='%(levelname)s: %(message)s')
+            logging.basicConfig(
+                level=logging.DEBUG, format="%(levelname)s: %(message)s"
+            )
             print("Debug mode enabled")
         else:
-            logging.basicConfig(level=logging.WARNING, format='%(levelname)s: %(message)s')
+            logging.basicConfig(
+                level=logging.WARNING, format="%(levelname)s: %(message)s"
+            )
 
         self.logger = logging.getLogger(__name__)
         self.client = DropCountrClient()
@@ -37,10 +41,10 @@ class DropCountrCLI:
         password = password or os.getenv("DROPCOUNTR_PASSWORD")
 
         # Safe debug logging for email
-        if email and '@' in email:
+        if email and "@" in email:
             email_debug = f"{email[:3]}***@{email.split('@')[1]}"
         else:
-            email_debug = f"'{email}'" if email else 'None'
+            email_debug = f"'{email}'" if email else "None"
         self.logger.debug(f"Login attempt with email: {email_debug}")
 
         if not email or not password:
@@ -78,7 +82,9 @@ class DropCountrCLI:
         try:
             self.logger.debug("Fetching service connections...")
             services = self.client.list_service_connections()
-            self.logger.debug(f"Retrieved {len(services) if services else 0} service connections")
+            self.logger.debug(
+                f"Retrieved {len(services) if services else 0} service connections"
+            )
 
             if not services:
                 self.logger.debug("No service connections returned from API")
@@ -86,7 +92,9 @@ class DropCountrCLI:
                 sys.exit(1)
 
             service = services[0]
-            self.logger.debug(f"Using first service: {service.name} (ID: {service.id}) at {service.address}")
+            self.logger.debug(
+                f"Using first service: {service.name} (ID: {service.id}) at {service.address}"
+            )
             print(f"Using service: {service.name} (ID: {service.id})")
             print(f"Address: {service.address}")
             return service.id
@@ -103,7 +111,9 @@ class DropCountrCLI:
             if services:
                 for service in services:
                     if service.id == service_id:
-                        self.logger.debug(f"Found service {service_id}: {service.name} at {service.address}")
+                        self.logger.debug(
+                            f"Found service {service_id}: {service.name} at {service.address}"
+                        )
                         return service
             self.logger.debug(f"Service {service_id} not found")
             return None
@@ -111,7 +121,9 @@ class DropCountrCLI:
             self.logger.debug(f"Error getting service details for {service_id}: {e}")
             return None
 
-    def _format_usage_data(self, usage_data: list, title: str, period: str = "day", verbose: bool = False) -> float | None:
+    def _format_usage_data(
+        self, usage_data: list, title: str, period: str = "day", verbose: bool = False
+    ) -> float | None:
         """Format and display usage data"""
         if not usage_data:
             print(f"{title}: No data available")
@@ -216,7 +228,9 @@ class DropCountrCLI:
                     period,
                 )
                 if yesterday_usage and yesterday_usage.usage_data:
-                    self._format_usage_data(yesterday_usage.usage_data, "Yesterday", period, verbose)
+                    self._format_usage_data(
+                        yesterday_usage.usage_data, "Yesterday", period, verbose
+                    )
                 else:
                     print("Yesterday: No data available")
             except Exception as e:
@@ -232,7 +246,9 @@ class DropCountrCLI:
             usage = self.client.get_usage(actual_service_id, start_dt, end_dt, period)
 
             if usage and usage.usage_data:
-                date_range = f"{start_dt.strftime('%Y-%m-%d')} to {end_dt.strftime('%Y-%m-%d')}"
+                date_range = (
+                    f"{start_dt.strftime('%Y-%m-%d')} to {end_dt.strftime('%Y-%m-%d')}"
+                )
                 if not (start_date or end_date or days):
                     date_range = "Last 7 Days"
                 self._format_usage_data(usage.usage_data, date_range, period, verbose)
@@ -262,7 +278,9 @@ class DropCountrCLI:
         try:
             self.logger.debug("Services command: Fetching service connections...")
             services = self.client.list_service_connections()
-            self.logger.debug(f"Services command: Retrieved {len(services) if services else 0} services")
+            self.logger.debug(
+                f"Services command: Retrieved {len(services) if services else 0} services"
+            )
 
             if not services:
                 self.logger.debug("Services command: No services found")
@@ -296,9 +314,9 @@ def main() -> None:
 
     # Check for debug flag and remove it from sys.argv before Fire processes it
     debug = False
-    if '--debug' in sys.argv:
+    if "--debug" in sys.argv:
         debug = True
-        sys.argv.remove('--debug')
+        sys.argv.remove("--debug")
 
     # Create CLI instance with debug flag
     cli = DropCountrCLI(debug=debug)

--- a/pydropcountr/cli.py
+++ b/pydropcountr/cli.py
@@ -127,7 +127,7 @@ class DropCountrCLI:
             gallons = record.total_gallons
             total_gallons += gallons
             leak_indicator = " 🚨" if record.is_leaking else ""
-            
+
             if verbose:
                 # Show raw data
                 print(f"  {date_str}: {gallons:,.1f} gallons{leak_indicator}")

--- a/pydropcountr/pydropcountr.py
+++ b/pydropcountr/pydropcountr.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field
 
 class UsageData(BaseModel):
     """Represents a single usage data record from DropCountr"""
+
     during: str = Field(description="Time period for this usage record")
     total_gallons: float = Field(ge=0, description="Total water usage in gallons")
     irrigation_gallons: float = Field(ge=0, description="Irrigation usage in gallons")
@@ -22,7 +23,7 @@ class UsageData(BaseModel):
     @property
     def start_date(self) -> datetime:
         """Parse and return the start date from the during field as timezone-aware datetime"""
-        dt_str = self.during.split('/')[0].replace('Z', '')
+        dt_str = self.during.split("/")[0].replace("Z", "")
         dt = datetime.fromisoformat(dt_str)
         if self._timezone:
             return dt.replace(tzinfo=self._timezone)
@@ -31,7 +32,7 @@ class UsageData(BaseModel):
     @property
     def end_date(self) -> datetime:
         """Parse and return the end date from the during field as timezone-aware datetime"""
-        dt_str = self.during.split('/')[1].replace('Z', '')
+        dt_str = self.during.split("/")[1].replace("Z", "")
         dt = datetime.fromisoformat(dt_str)
         if self._timezone:
             return dt.replace(tzinfo=self._timezone)
@@ -47,6 +48,7 @@ class UsageData(BaseModel):
 
 class UsageResponse(BaseModel):
     """Represents the full usage API response"""
+
     usage_data: list[UsageData] = Field(description="List of usage data records")
     total_items: int = Field(ge=0, description="Total number of items in response")
     api_id: str = Field(description="API identifier for this response")
@@ -55,6 +57,7 @@ class UsageResponse(BaseModel):
 
 class ServiceConnection(BaseModel):
     """Represents a service connection from DropCountr"""
+
     id: int = Field(description="Unique service connection identifier")
     name: str = Field(description="Service connection name")
     address: str = Field(description="Service address")
@@ -65,17 +68,17 @@ class ServiceConnection(BaseModel):
     api_id: str | None = Field(None, description="API identifier")
 
     @classmethod
-    def from_api_response(cls, data: dict) -> 'ServiceConnection':
+    def from_api_response(cls, data: dict) -> "ServiceConnection":
         """Create ServiceConnection from API response data"""
         return cls(
-            id=data.get('id', 0),
-            name=data.get('name', ''),
-            address=data.get('address', ''),
-            account_number=data.get('account_number'),
-            service_type=data.get('service_type'),
-            status=data.get('status'),
-            meter_serial=data.get('meter_serial'),
-            api_id=data.get('@id')
+            id=data.get("id", 0),
+            name=data.get("name", ""),
+            address=data.get("address", ""),
+            account_number=data.get("account_number"),
+            service_type=data.get("service_type"),
+            status=data.get("status"),
+            meter_serial=data.get("meter_serial"),
+            api_id=data.get("@id"),
         )
 
 
@@ -103,13 +106,13 @@ class DropCountrClient:
             # Format as ISO string with milliseconds and Z suffix
             iso_string = dt.isoformat()
             # Add milliseconds if not present
-            if '.' not in iso_string:
-                iso_string += '.000'
+            if "." not in iso_string:
+                iso_string += ".000"
             # Replace timezone info with Z
-            if iso_string.endswith('+00:00'):
-                iso_string = iso_string.replace('+00:00', 'Z')
-            elif not iso_string.endswith('Z'):
-                iso_string += 'Z'
+            if iso_string.endswith("+00:00"):
+                iso_string = iso_string.replace("+00:00", "Z")
+            elif not iso_string.endswith("Z"):
+                iso_string += "Z"
             return iso_string
         else:
             raise ValueError(f"Expected datetime or str, got {type(dt)}")
@@ -131,10 +134,7 @@ class DropCountrClient:
         login_url = f"{self.base_url}/login"
         self.logger.debug(f"Attempting login to {login_url}")
 
-        login_data = {
-            "email": email,
-            "password": password
-        }
+        login_data = {"email": email, "password": password}
 
         try:
             self.logger.debug("Sending POST request to login endpoint")
@@ -146,7 +146,7 @@ class DropCountrClient:
             # Check if we have a rack.session cookie
             cookies = dict(self.session.cookies)
             self.logger.debug(f"Cookies after login: {list(cookies.keys())}")
-            if 'rack.session' in self.session.cookies:
+            if "rack.session" in self.session.cookies:
                 self.logger.debug("rack.session cookie found - login successful")
                 self.logged_in = True
                 return True
@@ -155,7 +155,10 @@ class DropCountrClient:
                 # Login failed - check response for error indicators
                 if response.status_code == 200:
                     # Might be a redirect or error page, check content
-                    if "login" in response.url.lower() or "error" in response.text.lower():
+                    if (
+                        "login" in response.url.lower()
+                        or "error" in response.text.lower()
+                    ):
                         self.logger.debug("Login page or error detected in response")
                         self.logged_in = False
                         return False
@@ -175,7 +178,13 @@ class DropCountrClient:
         self.session.cookies.clear()
         self.logged_in = False
 
-    def get_usage(self, service_connection_id: int, start_date: datetime | str, end_date: datetime | str, period: str = "day") -> UsageResponse | None:
+    def get_usage(
+        self,
+        service_connection_id: int,
+        start_date: datetime | str,
+        end_date: datetime | str,
+        period: str = "day",
+    ) -> UsageResponse | None:
         """
         Get usage data for a service connection
 
@@ -205,20 +214,17 @@ class DropCountrClient:
         url = f"{self.base_url}/api/service_connections/{service_connection_id}/usage"
 
         headers = {
-            'accept': 'application/vnd.dropcountr.api+json;version=2',
-            'accept-language': 'en-US,en;q=0.9',
-            'content-type': 'application/json',
-            'referer': f'{self.base_url}/dashboard',
-            'sec-fetch-dest': 'empty',
-            'sec-fetch-mode': 'cors',
-            'sec-fetch-site': 'same-origin',
-            'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36'
+            "accept": "application/vnd.dropcountr.api+json;version=2",
+            "accept-language": "en-US,en;q=0.9",
+            "content-type": "application/json",
+            "referer": f"{self.base_url}/dashboard",
+            "sec-fetch-dest": "empty",
+            "sec-fetch-mode": "cors",
+            "sec-fetch-site": "same-origin",
+            "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
         }
 
-        params = {
-            'during': during,
-            'period': period
-        }
+        params = {"during": during, "period": period}
 
         try:
             response = self.session.get(url, headers=headers, params=params)
@@ -226,27 +232,27 @@ class DropCountrClient:
 
             data = response.json()
 
-            if 'data' not in data:
+            if "data" not in data:
                 return None
 
             # Parse usage data
             usage_records = []
-            for record in data['data']['member']:
+            for record in data["data"]["member"]:
                 usage_data = UsageData(
-                    during=record['during'],
-                    total_gallons=record['total_gallons'],
-                    irrigation_gallons=record['irrigation_gallons'],
-                    irrigation_events=record['irrigation_events'],
-                    is_leaking=record['is_leaking']
+                    during=record["during"],
+                    total_gallons=record["total_gallons"],
+                    irrigation_gallons=record["irrigation_gallons"],
+                    irrigation_events=record["irrigation_events"],
+                    is_leaking=record["is_leaking"],
                 )
                 usage_data.set_timezone(self.timezone)
                 usage_records.append(usage_data)
 
             return UsageResponse(
                 usage_data=usage_records,
-                total_items=data['data']['totalItems'],
-                api_id=data['data']['@id'],
-                consumed_via_id=data['data']['consumed_via']['@id']
+                total_items=data["data"]["totalItems"],
+                api_id=data["data"]["@id"],
+                consumed_via_id=data["data"]["consumed_via"]["@id"],
             )
 
         except requests.RequestException as e:
@@ -254,7 +260,9 @@ class DropCountrClient:
         except (KeyError, ValueError):
             return None
 
-    def get_service_connection(self, service_connection_id: int) -> ServiceConnection | None:
+    def get_service_connection(
+        self, service_connection_id: int
+    ) -> ServiceConnection | None:
         """
         Get details for a specific service connection
 
@@ -297,13 +305,13 @@ class DropCountrClient:
         self.logger.debug(f"Fetching user data from {url}")
 
         headers = {
-            'accept': 'application/vnd.dropcountr.api+json;version=2',
-            'accept-language': 'en-US,en;q=0.9',
-            'referer': f'{self.base_url}/dashboard',
-            'sec-fetch-dest': 'empty',
-            'sec-fetch-mode': 'cors',
-            'sec-fetch-site': 'same-origin',
-            'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36'
+            "accept": "application/vnd.dropcountr.api+json;version=2",
+            "accept-language": "en-US,en;q=0.9",
+            "referer": f"{self.base_url}/dashboard",
+            "sec-fetch-dest": "empty",
+            "sec-fetch-mode": "cors",
+            "sec-fetch-site": "same-origin",
+            "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
         }
 
         try:
@@ -314,7 +322,9 @@ class DropCountrClient:
 
             data = response.json()
             self.logger.debug(f"User data response type: {type(data)}")
-            self.logger.debug(f"User data response length: {len(data) if isinstance(data, list | dict) else 'N/A'}")
+            self.logger.debug(
+                f"User data response length: {len(data) if isinstance(data, list | dict) else 'N/A'}"
+            )
 
             # Check for both response formats: [true, user_data] and {'data': user_data}
             user_data = None
@@ -322,19 +332,21 @@ class DropCountrClient:
                 # Old format: [true, user_data]
                 user_data = data[1]
                 self.logger.debug("Found user data in old format [true, user_data]")
-            elif isinstance(data, dict) and 'data' in data:
+            elif isinstance(data, dict) and "data" in data:
                 # New format: {'data': user_data}
-                user_data = data['data']
+                user_data = data["data"]
                 self.logger.debug("Found user data in new format {'data': user_data}")
             else:
                 self.logger.debug(f"Unexpected response format: {data}")
                 return None
 
             if user_data:
-                self.logger.debug(f"Found user data with keys: {list(user_data.keys()) if isinstance(user_data, dict) else 'Not a dict'}")
+                self.logger.debug(
+                    f"Found user data with keys: {list(user_data.keys()) if isinstance(user_data, dict) else 'Not a dict'}"
+                )
                 # Store user ID for potential future use
-                if 'id' in user_data:
-                    self.user_id = user_data['id']
+                if "id" in user_data:
+                    self.user_id = user_data["id"]
                     self.logger.debug(f"Stored user ID: {self.user_id}")
                 return dict(user_data)
 
@@ -367,46 +379,66 @@ class DropCountrClient:
 
             # First, get service connections from the current premise (in attributes)
             self.logger.debug("Checking current premise in user attributes...")
-            attributes = user_data.get('attributes', {})
-            self.logger.debug(f"User attributes keys: {list(attributes.keys()) if attributes else 'No attributes'}")
+            attributes = user_data.get("attributes", {})
+            self.logger.debug(
+                f"User attributes keys: {list(attributes.keys()) if attributes else 'No attributes'}"
+            )
 
-            service_connections_data = attributes.get('service_connections', [])
-            self.logger.debug(f"Found {len(service_connections_data)} service connections in current premise")
+            service_connections_data = attributes.get("service_connections", [])
+            self.logger.debug(
+                f"Found {len(service_connections_data)} service connections in current premise"
+            )
 
             for service_data in service_connections_data:
-                self.logger.debug(f"Processing service connection from current premise: {service_data.get('name', 'Unknown')}")
-                service_connection = self._create_service_connection_from_data(service_data, user_data)
+                self.logger.debug(
+                    f"Processing service connection from current premise: {service_data.get('name', 'Unknown')}"
+                )
+                service_connection = self._create_service_connection_from_data(
+                    service_data, user_data
+                )
                 if service_connection:
                     all_service_connections.append(service_connection)
 
             # Then, check all other premises
-            premises = user_data.get('premises', [])
+            premises = user_data.get("premises", [])
             self.logger.debug(f"Found {len(premises)} total premises to check")
 
             for premise in premises:
-                premise_url = premise.get('@id', '')
+                premise_url = premise.get("@id", "")
                 premise_id = self._extract_id_from_url(premise_url)
                 self.logger.debug(f"Checking premise: {premise_url}")
 
                 # Skip the current premise (already processed above)
-                current_premise_id = attributes.get('premise_id')
+                current_premise_id = attributes.get("premise_id")
                 if premise_id == current_premise_id:
-                    self.logger.debug(f"Skipping current premise {premise_id} (already processed)")
+                    self.logger.debug(
+                        f"Skipping current premise {premise_id} (already processed)"
+                    )
                     continue
 
                 # Fetch premise data
                 premise_data = self._get_premise_data(premise_id)
                 if premise_data:
-                    premise_service_connections = premise_data.get('service_connections', [])
-                    self.logger.debug(f"Found {len(premise_service_connections)} service connections in premise {premise_id}")
+                    premise_service_connections = premise_data.get(
+                        "service_connections", []
+                    )
+                    self.logger.debug(
+                        f"Found {len(premise_service_connections)} service connections in premise {premise_id}"
+                    )
 
                     for service_data in premise_service_connections:
-                        self.logger.debug(f"Processing service connection from premise {premise_id}: {service_data.get('name', 'Unknown')}")
-                        service_connection = self._create_service_connection_from_data(service_data, premise_data)
+                        self.logger.debug(
+                            f"Processing service connection from premise {premise_id}: {service_data.get('name', 'Unknown')}"
+                        )
+                        service_connection = self._create_service_connection_from_data(
+                            service_data, premise_data
+                        )
                         if service_connection:
                             all_service_connections.append(service_connection)
 
-            self.logger.debug(f"Total service connections found: {len(all_service_connections)}")
+            self.logger.debug(
+                f"Total service connections found: {len(all_service_connections)}"
+            )
             return all_service_connections if all_service_connections else None
 
         except (KeyError, ValueError, TypeError) as e:
@@ -430,19 +462,21 @@ class DropCountrClient:
         self.logger.debug(f"Fetching premise data from {url}")
 
         headers = {
-            'accept': 'application/vnd.dropcountr.api+json;version=2',
-            'accept-language': 'en-US,en;q=0.9',
-            'referer': f'{self.base_url}/dashboard',
-            'sec-fetch-dest': 'empty',
-            'sec-fetch-mode': 'cors',
-            'sec-fetch-site': 'same-origin',
-            'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36'
+            "accept": "application/vnd.dropcountr.api+json;version=2",
+            "accept-language": "en-US,en;q=0.9",
+            "referer": f"{self.base_url}/dashboard",
+            "sec-fetch-dest": "empty",
+            "sec-fetch-mode": "cors",
+            "sec-fetch-site": "same-origin",
+            "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
         }
 
         try:
             self.logger.debug(f"Sending GET request to /api/premises/{premise_id}")
             response = self.session.get(url, headers=headers)
-            self.logger.debug(f"Premise {premise_id} response status: {response.status_code}")
+            self.logger.debug(
+                f"Premise {premise_id} response status: {response.status_code}"
+            )
             response.raise_for_status()
 
             data = response.json()
@@ -452,16 +486,24 @@ class DropCountrClient:
             premise_data = None
             if isinstance(data, list) and len(data) == 2 and data[0] is True:
                 premise_data = data[1]
-                self.logger.debug(f"Found premise {premise_id} data in old format [true, premise_data]")
-            elif isinstance(data, dict) and 'data' in data:
-                premise_data = data['data']
-                self.logger.debug(f"Found premise {premise_id} data in new format with 'data' key")
+                self.logger.debug(
+                    f"Found premise {premise_id} data in old format [true, premise_data]"
+                )
+            elif isinstance(data, dict) and "data" in data:
+                premise_data = data["data"]
+                self.logger.debug(
+                    f"Found premise {premise_id} data in new format with 'data' key"
+                )
             else:
-                self.logger.debug(f"Unexpected premise {premise_id} response format: {type(data)}")
+                self.logger.debug(
+                    f"Unexpected premise {premise_id} response format: {type(data)}"
+                )
                 return None
 
             if premise_data:
-                self.logger.debug(f"Premise {premise_id} has {len(premise_data.get('service_connections', []))} service connections")
+                self.logger.debug(
+                    f"Premise {premise_id} has {len(premise_data.get('service_connections', []))} service connections"
+                )
                 return dict(premise_data)
 
             return None
@@ -473,7 +515,9 @@ class DropCountrClient:
             self.logger.debug(f"Error parsing premise {premise_id} data: {e}")
             return None
 
-    def _create_service_connection_from_data(self, service_data: dict, context_data: dict) -> ServiceConnection | None:
+    def _create_service_connection_from_data(
+        self, service_data: dict, context_data: dict
+    ) -> ServiceConnection | None:
         """
         Create a ServiceConnection object from service data and context
 
@@ -486,23 +530,23 @@ class DropCountrClient:
         """
         try:
             connection_data = {
-                'id': self._extract_id_from_url(service_data.get('@id', '')),
-                'name': service_data.get('name', ''),
-                'meter_id': service_data.get('meter_id', ''),
-                'measurement_period': service_data.get('measurement_period', ''),
-                'is_disconnected': service_data.get('is_disconnected', False),
-                '@id': service_data.get('@id', '')
+                "id": self._extract_id_from_url(service_data.get("@id", "")),
+                "name": service_data.get("name", ""),
+                "meter_id": service_data.get("meter_id", ""),
+                "measurement_period": service_data.get("measurement_period", ""),
+                "is_disconnected": service_data.get("is_disconnected", False),
+                "@id": service_data.get("@id", ""),
             }
 
             # Get address from context (could be user data or premise data)
-            address = ''
-            if 'address' in context_data:
-                address_data = context_data.get('address', {})
+            address = ""
+            if "address" in context_data:
+                address_data = context_data.get("address", {})
                 if isinstance(address_data, dict):
-                    street = address_data.get('street', '')
-                    city = address_data.get('city', '')
-                    state = address_data.get('state', '')
-                    zip_code = address_data.get('zip_code', '')
+                    street = address_data.get("street", "")
+                    city = address_data.get("city", "")
+                    state = address_data.get("state", "")
+                    zip_code = address_data.get("zip_code", "")
 
                     # Build full address
                     address_parts = [street]
@@ -516,30 +560,36 @@ class DropCountrClient:
                     if zip_code:
                         address_parts.append(zip_code)
 
-                    address = ', '.join(filter(None, address_parts))
+                    address = ", ".join(filter(None, address_parts))
                 else:
                     address = str(address_data)
-            elif 'name' in context_data:
-                address = context_data.get('name', '')
+            elif "name" in context_data:
+                address = context_data.get("name", "")
 
             # Get account info from context
-            account_number = context_data.get('account_id', '')
-            service_type = context_data.get('account_type', '')
-            if not service_type and 'attributes' in context_data:
-                service_type = context_data.get('attributes', {}).get('account_type', '')
+            account_number = context_data.get("account_id", "")
+            service_type = context_data.get("account_type", "")
+            if not service_type and "attributes" in context_data:
+                service_type = context_data.get("attributes", {}).get(
+                    "account_type", ""
+                )
 
-            self.logger.debug(f"Service {connection_data['id']}: address='{address}', account='{account_number}', type='{service_type}'")
+            self.logger.debug(
+                f"Service {connection_data['id']}: address='{address}', account='{account_number}', type='{service_type}'"
+            )
 
             # Create ServiceConnection with available data
             service_connection = ServiceConnection(
-                id=connection_data['id'],
-                name=connection_data['name'],
+                id=connection_data["id"],
+                name=connection_data["name"],
                 address=address,
                 account_number=account_number,
                 service_type=service_type,
-                status='active' if not connection_data['is_disconnected'] else 'disconnected',
-                meter_serial=connection_data['meter_id'],
-                api_id=connection_data['@id']
+                status="active"
+                if not connection_data["is_disconnected"]
+                else "disconnected",
+                meter_serial=connection_data["meter_id"],
+                api_id=connection_data["@id"],
             )
 
             return service_connection
@@ -553,6 +603,6 @@ class DropCountrClient:
         if not url:
             return 0
         try:
-            return int(url.split('/')[-1])
+            return int(url.split("/")[-1])
         except (ValueError, IndexError):
             return 0

--- a/test_login.py
+++ b/test_login.py
@@ -14,6 +14,7 @@ def test_client_creation():
     assert not client.is_logged_in()
     print("✓ Client creation test passed")
 
+
 def test_login_with_invalid_credentials():
     """Test login with obviously invalid credentials"""
     client = DropCountrClient()
@@ -26,6 +27,7 @@ def test_login_with_invalid_credentials():
     except Exception as e:
         print(f"✓ Invalid login test completed (exception: {e})")
 
+
 def test_usage_data_class():
     """Test the UsageData class"""
     usage = UsageData(
@@ -33,7 +35,7 @@ def test_usage_data_class():
         total_gallons=7.4805193,
         irrigation_gallons=0.0,
         irrigation_events=0.0,
-        is_leaking=False
+        is_leaking=False,
     )
 
     # Test property access
@@ -49,6 +51,7 @@ def test_usage_data_class():
     assert end_date.day == 2
 
     print("✓ UsageData class test passed")
+
 
 def test_datetime_conversion():
     """Test the datetime conversion functionality"""
@@ -66,6 +69,7 @@ def test_datetime_conversion():
 
     print("✓ Datetime conversion test passed")
 
+
 def test_get_usage_without_login():
     """Test that get_usage fails when not logged in"""
     client = DropCountrClient()
@@ -82,27 +86,29 @@ def test_get_usage_without_login():
     except Exception as e:
         print(f"✗ Unexpected exception: {e}")
 
+
 def test_service_connection_class():
     """Test the ServiceConnection class"""
     # Test creating from API response format
     api_data = {
-        'id': 1064520,
-        'name': 'Main Service',
-        'address': '123 Main St',
-        'account_number': 'ACC123',
-        'service_type': 'Water',
-        'status': 'Active',
-        'meter_serial': 'METER123',
-        '@id': 'https://dropcountr.com/api/service_connections/1064520'
+        "id": 1064520,
+        "name": "Main Service",
+        "address": "123 Main St",
+        "account_number": "ACC123",
+        "service_type": "Water",
+        "status": "Active",
+        "meter_serial": "METER123",
+        "@id": "https://dropcountr.com/api/service_connections/1064520",
     }
 
     service = ServiceConnection.from_api_response(api_data)
     assert service.id == 1064520
-    assert service.name == 'Main Service'
-    assert service.address == '123 Main St'
-    assert service.account_number == 'ACC123'
+    assert service.name == "Main Service"
+    assert service.address == "123 Main St"
+    assert service.account_number == "ACC123"
 
     print("✓ ServiceConnection class test passed")
+
 
 def test_service_methods_without_login():
     """Test that service methods fail when not logged in"""
@@ -122,9 +128,12 @@ def test_service_methods_without_login():
         client.list_service_connections()
         print("✗ Expected ValueError for list_service_connections without login")
     except ValueError:
-        print("✓ list_service_connections correctly raises ValueError when not logged in")
+        print(
+            "✓ list_service_connections correctly raises ValueError when not logged in"
+        )
     except Exception as e:
         print(f"✗ Unexpected exception: {e}")
+
 
 if __name__ == "__main__":
     print("Running basic tests for PyDropCountr...")
@@ -161,5 +170,6 @@ if __name__ == "__main__":
     print("    if usage:")
     print("        print(f'Total records: {usage.total_items}')")
     print("        for record in usage.usage_data[:3]:  # Show first 3 records")
-    print("            print(f'{record.start_date.date()}: {record.total_gallons} gallons')")
-
+    print(
+        "            print(f'{record.start_date.date()}: {record.total_gallons} gallons')"
+    )


### PR DESCRIPTION
## Summary

- **BREAKING CHANGE**: Fixed incorrect timezone handling where API timestamps were parsed as UTC when they're actually in local time
- Added configurable timezone support to `DropCountrClient` constructor (defaults to Pacific timezone)
- All `start_date` and `end_date` properties now return timezone-aware datetime objects in correct local time

## Problem

The DropCountr API returns timestamps like `"2025-06-19T11:00:00Z/2025-06-19T12:00:00Z"` but despite the 'Z' suffix, these are actually in local time (not UTC). The library was incorrectly parsing these as UTC, leading to wrong datetime objects.

## Solution

- **UsageData class**: Updated `start_date` and `end_date` properties to parse timestamps as local time using `zoneinfo.ZoneInfo`
- **DropCountrClient**: Added optional `timezone` parameter to constructor (defaults to `"America/Los_Angeles"`)
- **Timezone support**: Accepts IANA timezone names or `ZoneInfo` objects
- **Standard library**: Uses Python 3.12+ `zoneinfo` module (no new dependencies)

## API Changes

### Before (v0.1.2)
```python
client = DropCountrClient()
usage = client.get_usage(service_id, start_date, end_date)
for record in usage.usage_data:
    print(record.start_date)  # 2025-06-01 11:00:00+00:00 (WRONG - parsed as UTC)
```

### After (v0.1.3)
```python
# Default Pacific timezone
client = DropCountrClient()
usage = client.get_usage(service_id, start_date, end_date)
for record in usage.usage_data:
    print(record.start_date)  # 2025-06-01 11:00:00-07:00 (CORRECT - local time)

# Custom timezone
client = DropCountrClient(timezone="America/New_York")
# or
from zoneinfo import ZoneInfo
client = DropCountrClient(timezone=ZoneInfo("UTC"))
```

## Migration Guide

**Who's affected**: Users who depend on the datetime behavior of `start_date` and `end_date` properties.

**Required changes**: If you were working around the incorrect UTC timestamps, update your code since datetimes are now correctly timezone-aware in local time.

## Test plan

- [x] All existing tests pass
- [x] Type checking with MyPy passes
- [x] Linting with ruff passes
- [x] Updated documentation (README, CHANGELOG, CLAUDE.md)
- [x] Verified timezone-aware datetime objects are returned correctly

🤖 Generated with [Claude Code](https://claude.ai/code)