### PR TITLE
chore: remove unused hello module

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -1,6 +1,0 @@
-def main():
-    print("Hello from pydropcountr!")
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## Summary
- Remove the unused `hello.py` scaffold module left at the repository root.
- Confirmed there are no references to the module in the codebase.

## Test Plan
- `uv run ruff check .`
- `uv run pytest`

Opened by Hermes Agent as a small weekly maintenance improvement for review.